### PR TITLE
Substitute convert('RGB') for convert('RGBA')

### DIFF
--- a/index.py
+++ b/index.py
@@ -67,12 +67,12 @@ def generate_unique_images(amount, config):
         layers[index] = Image.open(f'{config["layers"][index]["trait_path"]}/{trait_files[attr][item[attr]]}.png').convert('RGBA')
 
     if len(layers) == 1:
-      rgb_im = layers[0].convert('RGB')
+      rgb_im = layers[0].convert('RGBA')
       file_name = str(item["tokenId"]) + ".png"
       rgb_im.save("./images/" + file_name)
     elif len(layers) == 2:
       main_composite = Image.alpha_composite(layers[0], layers[1])
-      rgb_im = main_composite.convert('RGB')
+      rgb_im = main_composite.convert('RGBA')
       file_name = str(item["tokenId"]) + ".png"
       rgb_im.save("./images/" + file_name)
     elif len(layers) >= 3:
@@ -81,7 +81,7 @@ def generate_unique_images(amount, config):
       layers.pop(0)
       for index, remaining in enumerate(layers):
         main_composite = Image.alpha_composite(main_composite, remaining)
-      rgb_im = main_composite.convert('RGB')
+      rgb_im = main_composite.convert('RGBA')
       file_name = str(item["tokenId"]) + ".png"
       rgb_im.save("./images/" + file_name)
   


### PR DESCRIPTION
Using convert('RGBA') for all instances allows the final composite image to have a transparent background if the background layer isn't perfectly squared nor rectangular.