### PR TITLE
fix build_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following commands are available:
 | Command               | Usage                                                                   | Description                                                                          |
 | --------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `generate`            | `python3 main.py generate --config <config> [options]`                  | Generates a set of images using the provided configuration file.                     |
-| `build_configuration` | `python3 main.py build_configuration --trait-dir <trait_dir> [options]` | Builds a configuration file from a directory of traits.                              |
+| `build_config` | `python3 main.py build_config --trait-dir <trait_dir> [options]` | Builds a configuration file from a directory of traits.                              |
 | `validate`            | `python3 main.py validate --config <config> [options]`                  | Validates a configuration file.                                                      |
 | `update_metadata`     | `python3 main.py update_metadata --image-path <config> [options]`       | Updates the metadata files for all generated images at the provided `--output` path. |
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -14,7 +14,7 @@ def generate_config(trait_dir: str, output: str, verbose: int) -> None:
     # calculate weight
     weight = []
     for i in range(len(item_list)):
-        weight.append(100 / len(item_list[i]))
+        weight.append(int((100 / len(item_list[i]))))
         for j in range(len(item_list[i])):
             item_list[i][j] = item_list[i][j].split(".")[0]
 


### PR DESCRIPTION
`generate` only work with `int` weight. So, we generate config with `int` weight.
_(currently, `build_config` gives `float` weight output)_
fix command in `README.md`